### PR TITLE
Respect property null value handling

### DIFF
--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -2,15 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.5;net45</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>0.9.17</Version>
+    <Version>0.9.18</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
     <PackageLicenseUrl>https://github.com/codecutout/JsonApiSerializer/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
-    <AssemblyVersion>0.9.17.0</AssemblyVersion>
-    <FileVersion>0.9.17.0</FileVersion>
+    <AssemblyVersion>0.9.18.0</AssemblyVersion>
+    <FileVersion>0.9.18.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/JsonApiSerializer/JsonConverters/DocumentRootConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/DocumentRootConverter.cs
@@ -95,8 +95,19 @@ namespace JsonApiSerializer.JsonConverters
 
                 //respect the serializers null handling value
                 var propValue = prop.ValueProvider.GetValue(value);
-                if (propValue == null && serializer.NullValueHandling == NullValueHandling.Ignore)
-                    continue;
+                if (propValue == null)
+                {
+                    if (prop.NullValueHandling != null)
+                    {
+                        if (prop.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                    else
+                    {
+                        if (serializer.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                }
 
                 //A document MAY contain any of these top-level members: jsonapi, links, included
                 //We are also allowing everything else they happen to have on the root document

--- a/src/JsonApiSerializer/JsonConverters/ErrorConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ErrorConverter.cs
@@ -59,8 +59,19 @@ namespace JsonApiSerializer.JsonConverters
             foreach (var prop in contract.Properties.Where(x => !x.Ignored))
             {
                 var propValue = prop.ValueProvider.GetValue(value);
-                if (propValue == null && serializer.NullValueHandling == NullValueHandling.Ignore)
-                    continue;
+                if (propValue == null)
+                {
+                    if (prop.NullValueHandling != null)
+                    {
+                        if (prop.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                    else
+                    {
+                        if (serializer.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                }
 
                 writer.WritePropertyName(prop.PropertyName);
                 serializer.Serialize(writer, propValue);

--- a/src/JsonApiSerializer/JsonConverters/LinkConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/LinkConverter.cs
@@ -47,8 +47,19 @@ namespace JsonApiSerializer.JsonConverters
             foreach (var prop in contract.Properties.Where(x => !x.Ignored))
             {
                 var propValue = prop.ValueProvider.GetValue(value);
-                if (propValue == null && serializer.NullValueHandling == NullValueHandling.Ignore)
-                    continue;
+                if (propValue == null)
+                {
+                    if (prop.NullValueHandling != null)
+                    {
+                        if (prop.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                    else
+                    {
+                        if (serializer.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                }
                 outputProperties.Add(new KeyValuePair<string, object>(prop.PropertyName, propValue));
               
             }

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -163,8 +163,19 @@ namespace JsonApiSerializer.JsonConverters
             foreach (var prop in contract.Properties.Where(x=>!x.Ignored))
             {
                 var propValue = prop.ValueProvider.GetValue(value);
-                if (propValue == null && serializer.NullValueHandling == NullValueHandling.Ignore)
-                    continue;
+                if (propValue == null)
+                {
+                    if (prop.NullValueHandling != null)
+                    {
+                        if (prop.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                    else
+                    {
+                        if (serializer.NullValueHandling == NullValueHandling.Ignore)
+                            continue;
+                    }
+                }
 
                 switch (prop.PropertyName)
                 {
@@ -257,9 +268,19 @@ namespace JsonApiSerializer.JsonConverters
 
                 //ignore null properties
                 var propValue = prop.ValueProvider.GetValue(value);
-                if (propValue == null && serializer.NullValueHandling == NullValueHandling.Ignore)
-                    return false;
-
+                if (propValue == null)
+                {
+                    if (prop.NullValueHandling != null)
+                    {
+                        if (prop.NullValueHandling == NullValueHandling.Ignore)
+                            return false;
+                    }
+                    else
+                    {
+                        if (serializer.NullValueHandling == NullValueHandling.Ignore)
+                            return false;
+                    }
+                }
                 //we have another property with a value
                 return true;
             });

--- a/src/JsonApiSerializer/Util/ReaderUtil.cs
+++ b/src/JsonApiSerializer/Util/ReaderUtil.cs
@@ -93,6 +93,16 @@ namespace JsonApiSerializer.Util
         }
 
         /// <summary>
+        /// Determines if the property is able to be populated
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        public static bool CanPopulateProperty(JsonProperty property)
+        {
+            return !(property == null || property.Ignored || !property.Writable);
+        }
+
+        /// <summary>
         /// Attempt to populate the property with the value from the serializer
         /// </summary>
         /// <param name="serializer"></param>
@@ -102,7 +112,7 @@ namespace JsonApiSerializer.Util
         /// <returns><c>True</c> if the property could be set otherwise <c>false</c></returns>
         public static bool TryPopulateProperty(JsonSerializer serializer, object obj, JsonProperty property, JsonReader value)
         {
-            if (property == null || property.Ignored || !property.Writable)
+            if (!CanPopulateProperty(property))
             {
                 return false;
             }

--- a/tests/JsonApiSerializer.Test/DeserializationTests/RelationshipDeserializationTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/RelationshipDeserializationTests.cs
@@ -1,4 +1,5 @@
-﻿using JsonApiSerializer.Test.Models.Articles;
+﻿using JsonApiSerializer.JsonApi;
+using JsonApiSerializer.Test.Models.Articles;
 using JsonApiSerializer.Test.TestUtils;
 using Newtonsoft.Json;
 using System;
@@ -55,6 +56,34 @@ namespace JsonApiSerializer.Test.DeserializationTests
             var article = articles[0];
             Assert.Equal(null, article.Author);
             Assert.Equal(0, article.Comments.Count);
+        }
+
+        [Fact]
+        public void When_relationship_dictionary_should_deserialize()
+        {
+            var json = EmbeddedResource.Read("Data.Articles.sample.json");
+
+            var articlesRoot = JsonConvert.DeserializeObject<DocumentRoot<ArticleWithRelationshipDictionary[]>>(
+                json,
+                new JsonApiSerializerSettings());
+
+
+            var comments = (dynamic)articlesRoot.Data[0].Relationships["comments"].Data;
+            Assert.Equal("5", comments[0].id.ToString());
+            Assert.Equal("comments", comments[0].type.ToString());
+            Assert.Equal("12", comments[1].id.ToString());
+            Assert.Equal("comments", comments[1].type.ToString());
+
+            var author = (dynamic)articlesRoot.Data[0].Relationships["author"].Data;
+            Assert.Equal("9", author.id.ToString());
+            Assert.Equal("people", author.type.ToString());
+
+            Assert.Equal(3, articlesRoot.Included.Count);
+            Assert.True(articlesRoot.Included.Any(x => x["id"].ToString() == "5" && x["type"].ToString() == "comments"));
+            Assert.True(articlesRoot.Included.Any(x => x["id"].ToString() == "12" && x["type"].ToString() == "comments"));
+            Assert.True(articlesRoot.Included.Any(x => x["id"].ToString() == "9" && x["type"].ToString() == "people"));
+
+
         }
 
 

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="3.50.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/tests/JsonApiSerializer.Test/Models/Articles/ArticleWithRelationshipDictionary.cs
+++ b/tests/JsonApiSerializer.Test/Models/Articles/ArticleWithRelationshipDictionary.cs
@@ -1,0 +1,23 @@
+﻿using JsonApiSerializer.JsonApi;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace JsonApiSerializer.Test.Models.Articles
+{
+    public class ArticleWithRelationshipDictionary
+    {
+        public string Type { get; set; } = "articles";
+
+        public string Id { get; set; }
+
+        public string Title { get; set; }
+
+        public Dictionary<string, Relationship<JToken>> Relationships { get; set; }
+
+        public Links Links { get; set; }
+    }
+}


### PR DESCRIPTION
Take into account NullValueHandling on each property:
```csharp
    public class Article
    {
        public string Type { get; set; } = "articles";

        public string Id { get; set; }

        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
        public string Title { get; set; }
    }
```