### PR TITLE
Empty relationship arrays will now be serialized in the correct relaionship node.

### DIFF
--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -2,15 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.5;net45</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
     <PackageLicenseUrl>https://github.com/codecutout/JsonApiSerializer/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
@@ -70,6 +70,15 @@ namespace JsonApiSerializer.JsonConverters
                 }
                 writer.WriteEndArray();
             });
+
+            var probe = writer as AttributeOrRelationshipProbe;
+            if (probe != null)
+            {
+                //This converter will only run if the element type is a resource object
+                //so this whole array should be in a relationship node. 
+                //We do it after processing to prevent any items within the list from overriding
+                probe.PropertyType = AttributeOrRelationshipProbe.Type.Relationship;
+            }
         }
     }
 }

--- a/tests/JsonApiSerializer.Test/SerializationTests/SerializationRelationshipTests.cs
+++ b/tests/JsonApiSerializer.Test/SerializationTests/SerializationRelationshipTests.cs
@@ -70,7 +70,40 @@ namespace JsonApiSerializer.Test.SerializationTests
                     }
                 ]
             }";
-            Assert.Equal(json, expectedjson, JsonStringEqualityComparer.Instance);
+            Assert.Equal(expectedjson, json, JsonStringEqualityComparer.Instance);
+        }
+
+        [Fact]
+        public void When_relationship_empty_array_should_output_empty_relationship()
+        {
+            var root = new DocumentRoot<Article>
+            {
+                Data = new Article
+                {
+                    Id = "1234",
+                    Title = "My Article",
+                    Comments = new List<Comment>()
+                    
+                }
+            };
+
+
+            var json = JsonConvert.SerializeObject(root, settings);
+            var expectedjson = @"{
+                ""data"": {
+                    ""id"": ""1234"",
+                    ""type"": ""articles"",
+                    ""attributes"": {
+                        ""title"": ""My Article""
+                    },
+                    ""relationships"": {
+                        ""comments"": {
+                            ""data"": []
+                            }
+                        }
+                    }
+                }";
+            Assert.Equal(expectedjson, json, JsonStringEqualityComparer.Instance);
         }
 
         [Fact]


### PR DESCRIPTION
Fixing issue #39 