### PR TITLE
[Bug] Incorrect output for object arrays

### DIFF
--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -23,11 +23,6 @@ namespace JsonApiSerializer.JsonConverters
 
         public override bool CanConvert(Type objectType)
         {
-            if (objectType == typeof(object))
-            {
-                return true;
-            }
-
             return TypeInfoShim.GetPropertyFromInhertianceChain(objectType.GetTypeInfo(), "Id") != null;
         }
 

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
@@ -21,8 +21,12 @@ namespace JsonApiSerializer.JsonConverters
 
         public override bool CanConvert(Type objectType)
         {
-            Type elementType;
-            return ListUtil.IsList(objectType, out elementType) && ResourceObjectConverter.CanConvert(elementType);
+            if (!ListUtil.IsList(objectType, out var elementType))
+            {
+                return false;
+            }
+
+            return ResourceObjectConverter.CanConvert(elementType) || elementType == typeof(object);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
@@ -46,8 +46,6 @@ namespace JsonApiSerializer.JsonConverters
             ReaderUtil.ReadUntilEnd(reader, preDataPath);
 
             return list;
-
-
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
@@ -24,7 +24,7 @@ namespace JsonApiSerializer.JsonConverters
             Type elementType;
             return ListUtil.IsList(objectType, out elementType) && ResourceObjectConverter.CanConvert(elementType);
         }
-        
+
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             object list;
@@ -33,7 +33,7 @@ namespace JsonApiSerializer.JsonConverters
 
             //read into the 'Data' path
             var preDataPath = ReaderUtil.ReadUntilStart(reader, DataPathRegex);
-            
+
             //we should be dealing with list types, but we also want the element type
             Type elementType;
             if (!ListUtil.IsList(objectType, out elementType))
@@ -46,8 +46,8 @@ namespace JsonApiSerializer.JsonConverters
             ReaderUtil.ReadUntilEnd(reader, preDataPath);
 
             return list;
-            
-           
+
+
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Data\Articles\sample.json" />

--- a/tests/JsonApiSerializer.Test/SerializationTests/AnonTests.cs
+++ b/tests/JsonApiSerializer.Test/SerializationTests/AnonTests.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using JsonApiSerializer.Test.TestUtils;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace JsonApiSerializer.Test.SerializationTests
+{
+    public class AnonTests
+    {
+        private JsonApiSerializerSettings settings = new JsonApiSerializerSettings
+        {
+            Formatting = Formatting.Indented
+        };
+
+        [Fact]
+        public void When_anonymous_types_should_serialize()
+        {
+            var root = new
+            {
+                Id = "hq",
+                Type = "Theives-Guild",
+                Leader = new
+                {
+                    Id = "bobby",
+                    Type = "Bandit",
+                    Hobbies = new[] { "croquet" }
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(root, settings);
+            var expectedjson = @"
+{
+  ""data"": {
+    ""id"": ""hq"",
+    ""type"": ""Theives-Guild"",
+    ""relationships"": {
+      ""leader"": {
+        ""data"": {
+          ""id"": ""bobby"",
+          ""type"": ""Bandit""
+        }
+      }
+    }
+  },
+  ""included"": [
+    {
+      ""id"": ""bobby"",
+      ""type"": ""Bandit"",
+      ""attributes"": {
+        ""hobbies"": [
+          ""croquet""
+        ]
+      }
+    }
+  ]
+}";
+            Assert.Equal(json, expectedjson, JsonStringEqualityComparer.Instance);
+        }
+
+        [Fact]
+        public void When_anonymous_types_array_should_serialize()
+        {
+            var root = new List<object>
+            {
+                (object)new
+                {
+                    id = "1",
+                    type = "bears",
+                    name = "yogi"
+                },
+                (object)new
+                {
+                    id = "1",
+                    type = "bears",
+                    name = "booboo"
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(root, settings);
+            var expectedjson = @"{
+  ""data"": [
+    {
+      ""id"": ""1"",
+      ""type"": ""bears"",
+      ""attributes"": {
+        ""name"": ""yogi""
+      }
+    },
+    {
+      ""id"": ""1"",
+      ""type"": ""bears"",
+      ""attributes"": {
+        ""name"": ""booboo""
+      }
+    }
+  ]
+}";
+            Assert.Equal(json, expectedjson, JsonStringEqualityComparer.Instance);
+        }
+
+    }
+}


### PR DESCRIPTION
When serializing an `object[]` the type information is erased because
there is no guarantee that the `ElementType` of the array is
homogeneous.

There is no real "fix" for this except to assume that we see an object
array we should blindly assume that the user wants to serialize this as
jsonapi.