### PR TITLE
bug: links that have a null value throw exceptions

### DIFF
--- a/src/JsonApiSerializer/JsonConverters/LinkConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/LinkConverter.cs
@@ -27,7 +27,7 @@ namespace JsonApiSerializer.JsonConverters
             {
                 link.Href = (string)reader.Value;
             }
-            else
+            else if(reader.TokenType != JsonToken.Null)
             {
                 serializer.Populate(reader, link);
             }

--- a/tests/JsonApiSerializer.Test/Data/Articles/sample-with-link-null.json
+++ b/tests/JsonApiSerializer.Test/Data/Articles/sample-with-link-null.json
@@ -1,0 +1,77 @@
+﻿{
+    "links": {
+        "self": "http://example.com/articles",
+        "prev": null,
+        "next": "http://example.com/articles?page[offset]=2",
+        "last": "http://example.com/articles?page[offset]=10"
+    },
+  "data": [{
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+        "title": "JSON API paints my bikeshed!"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "9" }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/comments",
+          "related": "http://example.com/articles/1/comments"
+        },
+        "data": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
+      }
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    }
+  }],
+  "included": [{
+    "type": "people",
+    "id": "9",
+    "attributes": {
+      "first-name": "Dan",
+      "last-name": "Gebhardt",
+      "twitter": "dgeb"
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }, {
+    "type": "comments",
+    "id": "5",
+    "attributes": {
+      "body": "First!"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "2" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/5"
+    }
+  }, {
+    "type": "comments",
+    "id": "12",
+    "attributes": {
+      "body": "I like XML better"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/12"
+    }
+  }]
+}

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDocumentRootTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDocumentRootTests.cs
@@ -60,6 +60,23 @@ namespace JsonApiSerializer.Test.DeserializationTests
         }
 
         [Fact]
+        public void When_document_root_with_null_link_should_deserialize()
+        {
+            var json = EmbeddedResource.Read("Data.Articles.sample-with-link-null.json");
+
+            var articlesRoot = JsonConvert.DeserializeObject<DocumentRoot<Article[]>>(
+                json,
+                new JsonApiSerializerSettings());
+
+            Assert.Equal(4, articlesRoot.Links.Count);
+            Assert.NotNull(articlesRoot.Links["self"]);
+            Assert.NotNull(articlesRoot.Links["next"]);
+            Assert.NotNull(articlesRoot.Links["last"]);
+            Assert.NotNull(articlesRoot.Links["prev"]);
+            Assert.Null(articlesRoot.Links["prev"].Href);
+        }
+
+        [Fact]
         public void When_document_root_with_list_should_deserialize()
         {
             var json = EmbeddedResource.Read("Data.Articles.sample.json");

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -5,11 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Data\Articles\sample-with-link-null.json" />
     <None Remove="Data\Articles\sample.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Data\Articles\author-comments-null.json" />
+    <EmbeddedResource Include="Data\Articles\sample-with-link-null.json" />
     <EmbeddedResource Include="Data\Articles\sample-error-two-class-single-include.json" />
     <EmbeddedResource Include="Data\Articles\sample-error-model-not-match-values.json" />
     <EmbeddedResource Include="Data\Articles\sample-error-attributes-not-object.json" />


### PR DESCRIPTION
Fixes non-standards links nodes such as the following breaking the deserialiser with an exception

"links": {
        "self": "/v1/products?page[size]=10&page[number]=1",
        "first": "/v1/products?page[size]=10&page[number]=1",
        "last": "/v1/products?page[size]=10&page[number]=2",
        "prev": null,
        "next": "/v1/products?page[size]=10&page[number]=2"
    },