### PR TITLE
Document alternative way to integrate with AspNetCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,4 +310,12 @@ public class Startup
 }
 ```
 
+An alternative approach to integrate with AspNetCore is overriding the `ContractResolver`:
+```csharp
+public void ConfigureServices(IServiceCollection services) {
+    // ...
+    services.AddJsonOptions(x => x.SerializerSettings.ContractResolver = new JsonApiSerializerSettings().ContractResolver);
+}
+```
+
 


### PR DESCRIPTION
This is how I have it working in my project. I never set it the way it's currently documented and I'm not completely sure if there's any difference.

Both input and output work for me.