### PR TITLE
[Feature] Ability to override default object creation (#63)

### DIFF
--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -2,15 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.5;net45</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.3.2</Version>
+    <Version>1.3.3</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
     <PackageLicenseUrl>https://github.com/codecutout/JsonApiSerializer/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
+    <AssemblyVersion>1.3.3.0</AssemblyVersion>
+    <FileVersion>1.3.3.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -55,7 +55,7 @@ namespace JsonApiSerializer.JsonConverters
 
                     if (!serializationData.Included.TryGetValue(reference, out existingValue))
                     {
-                        existingValue = contract.DefaultCreator();
+                        existingValue = CreateDefault(contract, reference.Type);
                         serializationData.Included.Add(reference, existingValue);
                     }
                     if (existingValue is JObject existingValueJObject)
@@ -65,7 +65,7 @@ namespace JsonApiSerializer.JsonConverters
                         //before the item). In these cases we will create a new object and read data from the JObject
                         dataReader = new ForkableJsonReader(existingValueJObject.CreateReader(), dataReader.SerializationDataToken);
                         dataReader.Read(); //JObject readers begin at Not Started
-                        existingValue = contract.DefaultCreator();
+                        existingValue = CreateDefault(contract, reference.Type);
                         serializationData.Included[reference] = existingValue;
                     }
                 }
@@ -320,6 +320,17 @@ namespace JsonApiSerializer.JsonConverters
         protected virtual string GenerateDefaultTypeName(Type type)
         {
             return type.Name.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Exposes contract to allow overriding object initialisation based on resource type during deserialization.
+        /// </summary>
+        /// <param name="contract"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        protected virtual object CreateDefault(JsonObjectContract contract, string type)
+        {
+            return contract.DefaultCreator();
         }
     }
 }

--- a/tests/JsonApiSerializer.Test/Data/Products/sample-product-with-images.json
+++ b/tests/JsonApiSerializer.Test/Data/Products/sample-product-with-images.json
@@ -1,0 +1,34 @@
+﻿{
+  "data": {
+    "type": "products",
+    "id": "1",
+    "attributes": {
+        "marketingName": "JSON API paints my bikeshed!"
+    },
+    "relationships": {
+      "content": {
+        "links": {
+          "self": "http://example.com/products/1/relationships/content",
+          "related": "http://example.com/products/1/content"
+        },
+        "data": { "type": "images", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/products/1"
+    }
+  },
+  "included": [
+    {
+      "type": "images",
+      "id": "9",
+      "attributes": {
+        "title": "Live Free or Die Hard",
+        "imageType": "jpg"
+      },
+      "links": {
+        "self": "http://example.com/images/9"
+      }
+    }
+  ]
+}

--- a/tests/JsonApiSerializer.Test/Data/Products/sample-product-with-videos.json
+++ b/tests/JsonApiSerializer.Test/Data/Products/sample-product-with-videos.json
@@ -1,0 +1,34 @@
+﻿{
+  "data": {
+    "type": "products",
+    "id": "1",
+    "attributes": {
+        "marketingName": "JSON API paints my bikeshed!"
+    },
+    "relationships": {
+      "content": {
+        "links": {
+          "self": "http://example.com/products/1/relationships/content",
+          "related": "http://example.com/products/1/content"
+        },
+        "data": { "type": "videos", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/products/1"
+    }
+  },
+  "included": [
+    {
+      "type": "videos",
+      "id": "9",
+      "attributes": {
+        "title": "Live Free or Die Hard",
+        "videoType": "mp4"
+      },
+      "links": {
+        "self": "http://example.com/videos/9"
+      }
+    }
+  ]
+}

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationCustomConverterTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationCustomConverterTests.cs
@@ -1,12 +1,59 @@
-﻿using JsonApiSerializer.Test.Models.Timer;
+﻿using System;
+using System.Collections.Generic;
+using JsonApiSerializer.JsonConverters;
+using JsonApiSerializer.Test.Models.Products;
+using JsonApiSerializer.Test.Models.Timer;
+using JsonApiSerializer.Test.TestUtils;
 using Newtonsoft.Json;
-using System;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
-namespace JsonApiSerializer.Test.SerializationTests
+namespace JsonApiSerializer.Test.DeserializationTests
 {
     public class DeserializationCustomConverterTests
     {
+        private class ProductContentConverter : ResourceObjectConverter
+        {
+            protected override object CreateDefault(JsonObjectContract contract, string type)
+            {
+                switch (type)
+                {
+                    case "videos":
+                        contract.DefaultCreator = () => new Video();
+                        break;
+                    case "images":
+                        contract.DefaultCreator = () => new Image();
+                        break;
+                }
+
+                return contract.DefaultCreator();
+            }
+        }
+
+        public static IEnumerable<object[]> ProductsTestData
+        {
+            get
+            {
+                yield return new object[]
+                    {EmbeddedResource.Read("Data.Products.sample-product-with-images.json"), typeof(Image)};
+                yield return new object[]
+                    {EmbeddedResource.Read("Data.Products.sample-product-with-videos.json"), typeof(Video)};
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ProductsTestData))]
+        public void When_resource_type_is_generic_should_deserialize(string json, Type type)
+        {
+            var product = JsonConvert.DeserializeObject<Product>(json, GetSerializerSettings());
+            Assert.IsType(type, product.Content.Data);
+        }
+
+        private static JsonSerializerSettings GetSerializerSettings()
+        {
+            return new JsonApiSerializerSettings(new ProductContentConverter());
+        }
+
         [Fact]
         public void When_custom_convertor_should_use_on_attributes()
         {
@@ -41,11 +88,10 @@ namespace JsonApiSerializer.Test.SerializationTests
 
             var settings = new JsonApiSerializerSettings();
             var timer = JsonConvert.DeserializeObject<Timer>(json, settings);
-            
+
             Assert.Equal(TimeSpan.FromSeconds(42), timer.Duration);
             Assert.Single(timer.SubTimer);
             Assert.Equal(TimeSpan.FromSeconds(142), timer.SubTimer[0].Duration);
         }
     }
 }
-

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <None Remove="Data\Articles\sample-with-link-null.json" />
     <None Remove="Data\Articles\sample.json" />
+    <None Remove="Data\Products\sample-product-with-images.json" />
+    <None Remove="Data\Products\sample-product-with-videos.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,6 +26,8 @@
     <EmbeddedResource Include="Data\Articles\sample.json" />
     <EmbeddedResource Include="Data\Errors\multiple.json" />
     <EmbeddedResource Include="Data\Errors\single.json" />
+    <EmbeddedResource Include="Data\Products\sample-product-with-images.json" />
+    <EmbeddedResource Include="Data\Products\sample-product-with-videos.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/JsonApiSerializer.Test/Models/Products/IMarketedContent.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/IMarketedContent.cs
@@ -1,0 +1,9 @@
+﻿namespace JsonApiSerializer.Test.Models.Products
+{
+    public interface IMarketedContent
+    {
+        string Type { get; }
+        string Id { get; set; }
+        string Title { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Products/Image.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/Image.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace JsonApiSerializer.Test.Models.Products
+{
+    public class Image : IMarketedContent
+    {
+        public static readonly string ResourceTypeName = "images";
+
+        [JsonProperty("imageType")] public string ImageType { get; set; }
+
+        [JsonProperty("title")] public string Title { get; set; }
+
+        public string Type { get; } = ResourceTypeName;
+        public string Id { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Products/Product.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/Product.cs
@@ -1,0 +1,19 @@
+﻿using JsonApiSerializer.JsonApi;
+using Newtonsoft.Json;
+
+namespace JsonApiSerializer.Test.Models.Products
+{
+    public class Product
+    {
+        public static readonly string ResourceTypeName = "products";
+        public string Type { get; } = ResourceTypeName;
+
+        public string Id { get; set; }
+
+        [JsonProperty("marketingName")]
+        public string MarketingName { get; set; }
+
+        [JsonProperty("content")]
+        public Relationship<IMarketedContent> Content { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Products/Video.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/Video.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace JsonApiSerializer.Test.Models.Products
+{
+    public class Video : IMarketedContent
+    {
+        public static readonly string ResourceTypeName = "videos";
+
+        [JsonProperty("videoType")] public string VideoType { get; set; }
+
+        [JsonProperty("title")] public string Title { get; set; }
+        public string Type { get; } = ResourceTypeName;
+        public string Id { get; set; }
+    }
+}


### PR DESCRIPTION
Added feature to check resource type before deserializing and provides ability to override default object creation

        protected virtual object CreateDefault(JsonObjectContract contract, string type)
        {
            return contract.DefaultCreator();
        }