### PR TITLE
Remove incorrect key from meta data access example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ json:api allows for additional information to be stored at objects and relations
 DocumentRoot<Article[]> articlesRoot = JsonConvert.DeserializeObject<DocumentRoot<Article[]>>(json, new JsonApiSerializerSettings());
 Assert.Equal("1.0" articlesRoot.JsonApi.Version);
 Assert.Equal("http://example.com/articles", articlesRoot.Links["self"].Href);
-Assert.Equal("2017-04-02T23:28:35", articlesRoot.Meta["self"]["created"]);
+Assert.Equal("2017-04-02T23:28:35", articlesRoot.Meta["created"]);
 ```
 
 ### Relationships


### PR DESCRIPTION
Just a tiny fix in the documentation.

Since the provided json:api document some lines above doesn't define a `"self"` attribute within the `meta` tag you would run into an error when trying to access the `"created"` attribute using the specified example.