### PR TITLE
Document: setting ContractResolver overrides custom JsonConverter passed into JsonApiSerializerSettings constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ This can be achieved by creating a custom `JsonConvertor` extending from `Resoru
 
 This convertor can be added into the system in a number of ways 
 
-1. Adding it globally to all resource objects by specifiying during the creation of the `JsonApiSerializerSettings`
+1. Adding it globally to all resource objects by specifiying during the creation of the `JsonApiSerializerSettings`.
+**Note that the custom converter is saved via the `ContractResolver` property. Therefore, if you also override the `JsonApiContractResolver` and set it as the `JsonApiSerializerSettings.ContractResolver`, make sure to pass in your custom `JsonConverter` to it's constructor.**
 ```csharp
 var settings = new JsonApiSerializerSettings(new MyTypeDeterminingResourceObjectConvertor())
 Article[] articles = JsonConvert.DeserializeObject<Article[]>(json, settings);

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ This can be achieved by creating a custom `JsonConvertor` extending from `Resoru
 This convertor can be added into the system in a number of ways 
 
 1. Adding it globally to all resource objects by specifiying during the creation of the `JsonApiSerializerSettings`.
+
 **Note that the custom converter is saved via the `ContractResolver` property. Therefore, if you also override the `JsonApiContractResolver` and set it as the `JsonApiSerializerSettings.ContractResolver`, make sure to pass in your custom `JsonConverter` to it's constructor.**
 ```csharp
 var settings = new JsonApiSerializerSettings(new MyTypeDeterminingResourceObjectConvertor())


### PR DESCRIPTION
I have some non-trivial customizations to JsonApiSerializer (which may be interesting to the larger community, but I'll leave that for another time).

I overrode `ResourceObjectConverter`, but could not figure out why it wasn't being called. I tried debugging - it wasn't being touched.

Finally, I looked through `JsonApiSerializer` source, and saw in the constructor of [the settings](url)
```       
public JsonApiSerializerSettings(JsonConverter resourceObjectConverter)
{
  ...
  ContractResolver = new JsonApiContractResolver(resourceObjectConverter);
  ...
```

Which meant that when I set the `ContractResolver` property post construction, I was losing my custom `JsonConverter`!
The solution, of course, was to pass in my custom `JsonConverter` to my custom `ContractResolver` constructor.

However, I think that should be documented, to save others the - experience that I had.