### PR TITLE
[feature] adds attribute to remap or ignore "Id"/"Type" properties on models

### DIFF
--- a/src/JsonApiSerializer/ContractResolvers/Attributes/JsonApiProperties.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Attributes/JsonApiProperties.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace JsonApiSerializer.ContractResolvers.Attributes
+{
+    public class JsonApiProperties : Attribute
+    {
+        public string Id { get; set; }
+
+        public string Type { get; set; }
+
+        public JsonApiProperties()
+        {
+            this.Id = string.Empty;
+            this.Type = string.Empty;
+        }
+    }
+}

--- a/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceIdentifierContract.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceIdentifierContract.cs
@@ -9,6 +9,9 @@ using System.Text;
 
 namespace JsonApiSerializer.ContractResolvers.Contracts
 {
+    using System.Reflection;
+    using Attributes;
+
     internal class ResourceIdentifierContract : JsonObjectContractWrap
     {
         public readonly JsonProperty IdProperty;
@@ -21,21 +24,27 @@ namespace JsonApiSerializer.ContractResolvers.Contracts
         {
             ResourceObjectProperty = jsonObjectContract.Properties.First(x => x.UnderlyingName == nameof(IResourceIdentifier<object>.Value));
 
+            var propertyAttr = jsonObjectContract.CreatedType.GetTypeInfo().GetCustomAttribute<JsonApiProperties>() ?? new JsonApiProperties();
+            var propertyNameId = propertyAttr.Id == string.Empty ? PropertyNames.Id : propertyAttr.Id;
+            var propertyNameType = propertyAttr.Type ==  string.Empty ? PropertyNames.Type : propertyAttr.Type;
+
             foreach (var prop in jsonObjectContract.Properties.Where(x => !x.Ignored))
             {
                 switch (prop.PropertyName)
                 {
                     //In addition, a resource object MAY contain any of these top - level members: links, meta, attributes, relationships
-                    case PropertyNames.Id: //Id is optional on base objects
-                        IdProperty = prop;
-                        break;
                     case PropertyNames.Meta:
                         MetaProperty = prop;
                         break;
-                    case PropertyNames.Type:
-                        TypeProperty = prop;
-                        break;
                     default:
+                        if (prop.PropertyName == propertyNameId)
+                        {
+                            IdProperty = prop;
+                        }
+                        else if (prop.PropertyName == propertyNameType)
+                        {
+                            TypeProperty = prop;
+                        }
                         break;
                 }
             }

--- a/src/JsonApiSerializer/JsonConverters/ResourceIdentifierConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceIdentifierConverter.cs
@@ -1,4 +1,5 @@
 ﻿using JsonApiSerializer.ContractResolvers;
+using JsonApiSerializer.ContractResolvers.Attributes;
 using JsonApiSerializer.ContractResolvers.Contracts;
 using JsonApiSerializer.Exceptions;
 using JsonApiSerializer.JsonApi.WellKnown;
@@ -11,12 +12,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.JsonConverters
 {
-    using ContractResolvers.Attributes;
-
     internal class ResourceIdentifierConverter : JsonConverter
     {
         private readonly Func<Type, bool> isResourceObject;

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -1,4 +1,5 @@
-using JsonApiSerializer.ContractResolvers;
+﻿using JsonApiSerializer.ContractResolvers;
+using JsonApiSerializer.ContractResolvers.Attributes;
 using JsonApiSerializer.ContractResolvers.Contracts;
 using JsonApiSerializer.Exceptions;
 using JsonApiSerializer.JsonApi;
@@ -18,8 +19,6 @@ using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.JsonConverters
 {
-    using ContractResolvers.Attributes;
-
     /// <summary>
     /// Provides functionality to convert a JsonApi resource object into a .NET object
     /// </summary>

--- a/tests/JsonApiSerializer.Test/Data/Articles/sample-with-mapped-attributes.json
+++ b/tests/JsonApiSerializer.Test/Data/Articles/sample-with-mapped-attributes.json
@@ -1,0 +1,75 @@
+﻿{
+  "links": {
+    "self": "http://example.com/articles",
+    "next": "http://example.com/articles?page[offset]=2",
+    "last": "http://example.com/articles?page[offset]=10"
+  },
+  "data": {
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+      "title": "JSON API paints my bikeshed!"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "dan@test.com" }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/comments",
+          "related": "http://example.com/articles/1/comments"
+        },
+        "data": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
+      }
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    }
+  },
+  "included": [{
+    "type": "people",
+    "id": "dan@test.com",
+    "attributes": {
+      "id": 123,
+      "type": "sample",
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }, {
+    "type": "comments",
+    "id": "5",
+    "attributes": {
+      "body": "First!"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "2" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/5"
+    }
+  }, {
+    "type": "comments",
+    "id": "12",
+    "attributes": {
+      "body": "I like XML better"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/12"
+    }
+  }]
+}

--- a/tests/JsonApiSerializer.Test/Data/Articles/single-item-mapped-attributes.json
+++ b/tests/JsonApiSerializer.Test/Data/Articles/single-item-mapped-attributes.json
@@ -1,0 +1,78 @@
+﻿{
+  "links": {
+    "self": "http://example.com/articles",
+    "next": "http://example.com/articles?page[offset]=2",
+    "last": "http://example.com/articles?page[offset]=10"
+  },
+  "data": {
+    "type": "articles",
+    "id": "1",
+    "attributes": {
+      "id": 123,
+      "type": "blog",
+      "title": "JSON API paints my bikeshed!"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/author",
+          "related": "http://example.com/articles/1/author"
+        },
+        "data": { "type": "people", "id": "9" }
+      },
+      "comments": {
+        "links": {
+          "self": "http://example.com/articles/1/relationships/comments",
+          "related": "http://example.com/articles/1/comments"
+        },
+        "data": [
+          { "type": "comments", "id": "5" },
+          { "type": "comments", "id": "12" }
+        ]
+      }
+    },
+    "links": {
+      "self": "http://example.com/articles/1"
+    }
+  },
+  "included": [{
+    "type": "people",
+    "id": "9",
+    "attributes": {
+      "first-name": "Dan",
+      "last-name": "Gebhardt",
+      "twitter": "dgeb"
+    },
+    "links": {
+      "self": "http://example.com/people/9"
+    }
+  }, {
+    "type": "comments",
+    "id": "5",
+    "attributes": {
+      "body": "First!"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "2" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/5"
+    }
+  }, {
+    "type": "comments",
+    "id": "12",
+    "attributes": {
+      "body": "I like XML better"
+    },
+    "relationships": {
+      "author": {
+        "data": { "type": "people", "id": "9" }
+      }
+    },
+    "links": {
+      "self": "http://example.com/comments/12"
+    }
+  }]
+}

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationAttributeTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationAttributeTests.cs
@@ -30,6 +30,45 @@ namespace JsonApiSerializer.Test.DeserializationTests
         }
 
         [Fact]
+        public void When_fields_controlled_by_jsonapi_id_attribute_parse_correct()
+        {
+            var json = EmbeddedResource.Read("Data.Articles.single-item-mapped-attributes.json");
+
+            var settings = new JsonApiSerializerSettings();
+            var article = JsonConvert.DeserializeObject<ArticleWithJsonApiAttributes>(
+                json,
+                new JsonApiSerializerSettings());
+
+            Assert.Equal("1", article.InternalId);
+            Assert.Equal("JSON API paints my bikeshed!", article.Title);
+            Assert.Equal(123, article.Id);
+            Assert.Equal("blog", article.Type);
+
+            Assert.Null(article.Comments); //ignored
+        }
+
+        [Fact]
+        public void When_fields_controlled_by_jsonapi_id_attribute_parse_correct_included()
+        {
+            var json = EmbeddedResource.Read("Data.Articles.sample-with-mapped-attributes.json");
+
+            var settings = new JsonApiSerializerSettings();
+            var article = JsonConvert.DeserializeObject<ArticleWithIgnoredPropertiesPersonWithJsonApiAttributes>(
+                json,
+                new JsonApiSerializerSettings());
+
+            Assert.Equal("1", article.Id);
+            Assert.Null(article.Title); //ignored
+
+            var author = article.Author;
+            Assert.Equal(123, author.Id);
+            Assert.Equal("dan@test.com", author.Email);
+            Assert.Equal("sample", author.Type);
+
+            Assert.Null(article.Comments); //ignored
+        }
+
+        [Fact]
         public void When_fields_are_only_getters_should_ignore()
         {
             var json = EmbeddedResource.Read("Data.Articles.single-item.json");

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDateTimeTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDateTimeTests.cs
@@ -38,7 +38,7 @@ namespace JsonApiSerializer.Test.DeserializationTests
             var settings = new JsonApiSerializerSettings();
             var dateTimes = JsonConvert.DeserializeObject<DateTimes>(json,settings);
 
-            //Not happy with the behaviour to deserialize DateTime into DateTimeKind.Local, 
+            //Not happy with the behaviour to deserialize DateTime into DateTimeKind.Local,
             //but it is the Json.NET default
             Assert.Equal("2017-01-01T12:00:00+02:00", dateTimes.DateTimeOffset.ToString("yyyy-MM-ddTHH:mm:sszzz"));
             Assert.Equal("2017-01-01T10:00:00", dateTimes.DateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss"));
@@ -63,7 +63,7 @@ namespace JsonApiSerializer.Test.DeserializationTests
 }
 ";
             var settings = new JsonApiSerializerSettings();
-            var localOffset = new DateTimeOffset(new DateTime(0), TimeZoneInfo.Local.BaseUtcOffset).ToString("zzz");
+            var localOffset = new DateTimeOffset(DateTime.Now, TimeZoneInfo.Local.BaseUtcOffset).ToString("zzz");
 
             var dateTimes = JsonConvert.DeserializeObject<DateTimes>(json, settings);
 

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Data\Articles\author-comments-null.json" />
     <EmbeddedResource Include="Data\Articles\sample-with-full-link.json" />
+    <EmbeddedResource Include="Data\Articles\sample-with-mapped-attributes.json" />
     <EmbeddedResource Include="Data\Articles\sample-without-included.json" />
     <EmbeddedResource Include="Data\Articles\sample-with-inherited-types.json" />
     <EmbeddedResource Include="Data\Articles\sample-with-link-null.json" />
@@ -26,6 +27,7 @@
     <EmbeddedResource Include="Data\Articles\sample-error-id-not-string.json" />
     <EmbeddedResource Include="Data\Articles\sample-error-type-not-string.json" />
     <EmbeddedResource Include="Data\Articles\sample-out-of-order.json" />
+    <EmbeddedResource Include="Data\Articles\single-item-mapped-attributes.json" />
     <EmbeddedResource Include="Data\Articles\single-item.json" />
     <EmbeddedResource Include="Data\Articles\sample.json" />
     <EmbeddedResource Include="Data\Errors\multiple.json" />

--- a/tests/JsonApiSerializer.Test/Models/Articles/ArticleWithIgnoredPropertiesPersonWithJsonApiAttributes.cs
+++ b/tests/JsonApiSerializer.Test/Models/Articles/ArticleWithIgnoredPropertiesPersonWithJsonApiAttributes.cs
@@ -1,0 +1,23 @@
+﻿using JsonApiSerializer.JsonApi;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace JsonApiSerializer.Test.Models.Articles
+{
+    public class ArticleWithIgnoredPropertiesPersonWithJsonApiAttributes
+    {
+        public string Type { get; set; } = "articles";
+
+        public string Id { get; set; }
+
+        [JsonIgnore]
+        public string Title { get; set; }
+
+        public PersonWithJsonApiAttributes Author { get; set; }
+
+        [JsonIgnore]
+        public List<Comment> Comments { get; set; }
+
+        public Links Links { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Articles/ArticleWithJsonApiAttributes.cs
+++ b/tests/JsonApiSerializer.Test/Models/Articles/ArticleWithJsonApiAttributes.cs
@@ -1,0 +1,29 @@
+﻿using JsonApiSerializer.JsonApi;
+using System.Collections.Generic;
+
+namespace JsonApiSerializer.Test.Models.Articles
+{
+    using ContractResolvers.Attributes;
+    using Newtonsoft.Json;
+
+    [JsonApiProperties(Id = "internalId", Type = "resourceType")]
+    public class ArticleWithJsonApiAttributes
+    {
+        public string Type { get; set; } = "articles";
+
+        public string InternalId { get; set; }
+
+        public int Id { get; set; }
+
+        public string Title { get; set; }
+
+        public Person Author { get; set; }
+
+        [JsonIgnore]
+        public List<Comment> Comments { get; set; }
+
+        public Links Links { get; set; }
+
+        public string ResourceType { get; set; } = "articles";
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Articles/PersonWithJsonApiAttributes.cs
+++ b/tests/JsonApiSerializer.Test/Models/Articles/PersonWithJsonApiAttributes.cs
@@ -1,0 +1,19 @@
+﻿using JsonApiSerializer.JsonApi;
+using Newtonsoft.Json;
+
+namespace JsonApiSerializer.Test.Models.Articles
+{
+    using ContractResolvers.Attributes;
+
+    [JsonApiProperties(Id = "email", Type = "resourceType")]
+    public class PersonWithJsonApiAttributes
+    {
+        public int Id { get; set; }
+
+        public string Email { get; set; }
+
+        public string Type { get; set; }
+
+        public string ResourceType { get; set; } = "people";
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Articles/PersonWithJsonApiAttributesNoType.cs
+++ b/tests/JsonApiSerializer.Test/Models/Articles/PersonWithJsonApiAttributesNoType.cs
@@ -1,0 +1,17 @@
+﻿using JsonApiSerializer.JsonApi;
+using Newtonsoft.Json;
+
+namespace JsonApiSerializer.Test.Models.Articles
+{
+    using ContractResolvers.Attributes;
+
+    [JsonApiProperties(Type = null)]
+    public class PersonWithJsonApiAttributesNoType
+    {
+        public string Id { get; set; }
+
+        public string Email { get; set; }
+
+        public string Type { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/SerializationTests/SerializationAttributeTests.cs
+++ b/tests/JsonApiSerializer.Test/SerializationTests/SerializationAttributeTests.cs
@@ -43,6 +43,62 @@ namespace JsonApiSerializer.Test.SerializationTests
         }
 
         [Fact]
+        public void When_fields_controlled_by_jsonapi_attributes_should_respect_attributes()
+        {
+            var root = new DocumentRoot<PersonWithJsonApiAttributes>
+            {
+                Data = new PersonWithJsonApiAttributes
+                {
+                    Id = 1234, //treated as attribute
+                    Email = "john@test.com", //treated as id
+                    Type = "Employee", //treated as attribute
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(root, settings);
+
+            Assert.Equal(@"
+                {
+                  ""data"": {
+                    ""id"": ""john@test.com"",
+                    ""type"": ""people"",
+                    ""attributes"": {
+                      ""id"": 1234,
+                      ""type"": ""Employee"",
+                    }
+                  }
+                }".Trim(), json, JsonStringEqualityComparer.Instance);
+        }
+
+        [Fact]
+        public void When_fields_controlled_by_jsonapi_attributes_should_respect_attributes_no_type()
+        {
+            var root = new DocumentRoot<PersonWithJsonApiAttributesNoType>
+            {
+                Data = new PersonWithJsonApiAttributesNoType
+                {
+                    Id = "1234", //treated as attribute
+                    Email = "john@test.com", //treated as id
+                    Type = "Employee", //treated as attribute
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(root, settings);
+
+            Assert.Equal(@"
+                {
+                  ""data"": {
+                    ""id"": ""1234"",
+                    ""type"": ""personwithjsonapiattributesnotype"",
+                    ""attributes"": {
+                      ""email"": ""john@test.com"",
+                      ""type"": ""Employee"",
+                    }
+                  }
+                }".Trim(), json, JsonStringEqualityComparer.Instance);
+        }
+
+        [Fact]
         public void When_fields_controlled_by_jsonnet_nullinclude_attributes_should_include_null()
         {
             var root = new DocumentRoot<ArticleWithNullIncludeProperties>


### PR DESCRIPTION
**Problem**
Currently for models that contain `Id` or `Type` fields the serializer treats them as special as per JsonApi. A common fix involves to rename the properties:

```
class Foo {
  // public string Type {get; set;}
  public string FooType {get; set;}
}
```

Similar approach has to be followed if a model has an `Id` property but shouldn't be put into `relationships`, there the `Id` needs to be removed. 
While another solution is to create separate ViewModels and map the domain models - the same can be achieved with limited tampering via `Attributes`.

**How it works?**
This PR adds a `JsonApiProperties(Id = "mappedIdField", Type = "mappedTypeField")` attribute that can be set on a class to map the respective well-known fields. A value of `null` simply _hides_ the field from the parser and the resource is treated as if the property didn't exist on the original object.

```
// models
using JsonApiSerializer.ContractResolvers.Attributes;

[JsonApiProperties(Id = "customId")]
public class Article
{
    public int Id { get; set; }
    public string CustomId { get; set; }
    public string Name { get; set; }
    public Person Author { get; set; }
}

[JsonApiProperties(Type = null)]
public class Person
{
    public string Id { get; set; }
    public string Name { get; set; }
    public string Type { get; set; }
}

// program
var o = new Article
            {
                Id = 1,
                CustomId = "id-1",
                Name = "I love JSON",
                Author = new Person
                {
                    Id = "2",
                    Name = "John",
                    Type = "admin"
                }
            };

            var json = JsonConvert.SerializeObject(o, new JsonApiSerializerSettings());
            Console.WriteLine(json);

            var article = JsonConvert.DeserializeObject<Article>(json, new JsonApiSerializerSettings());

            Console.WriteLine("--------");

            Console.WriteLine($@"article.Id = {article.Id}
article.CustomId = {article.CustomId}
article.Name = {article.Name}
article.Author.Id = {article.Author.Id}
article.Author.Name = {article.Author.Name}
article.Author.Type = {article.Author.Type}");
```

**Output**
```
{"data":{"id":"id-1","type":"article","attributes":{"id":1,"name":"I love JSON"},"relationships":{"author":{"data":{"id":"2","type":"person"}}}},"included":[{"id":"2","type":"person","attributes":{"name":"John","type":"admin"}}]}
--------
article.Id = 1
article.CustomId = id-1
article.Name = I love JSON
article.Author.Id = 2
article.Author.Name = John
article.Author.Type = admin
```
