### PR TITLE
Modify `DocumentRootConverter` to force interpretation of `data` section first

### DIFF
--- a/tests/JsonApiSerializer.Test/Data/Products/sample-included-first-recursive.json
+++ b/tests/JsonApiSerializer.Test/Data/Products/sample-included-first-recursive.json
@@ -1,0 +1,62 @@
+﻿{
+  "included": [
+    {
+      "id": "3d29c4a7-2eed-409d-9aa1-a8f5ca7f8f46",
+      "type": "product",
+      "attributes": {
+        "name": "OneProduct",
+        "description": "The first product"
+      },
+      "relationships": {
+        "category": {
+          "data": {
+            "id": "d00572f8-9075-4648-8a8f-e084972dfeaa",
+            "type": "category"
+          }
+        },
+        "sellers": {
+          "data": [
+            {
+              "id": "fa0e66a9-c798-4fd8-ab7b-1087ac5251fb",
+              "type": "seller"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "fa0e66a9-c798-4fd8-ab7b-1087ac5251fb",
+      "type": "seller",
+      "attributes": {
+        "name": "OneSeller"
+      },
+      "relationships": {
+        "products": {
+          "data": [
+            {
+              "id": "3d29c4a7-2eed-409d-9aa1-a8f5ca7f8f46",
+              "type": "product"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "data": {
+    "id": "d00572f8-9075-4648-8a8f-e084972dfeaa",
+    "type": "category",
+    "attributes": {
+      "name": "MyCategory"
+    },
+    "relationships": {
+      "products": {
+        "data": [
+          {
+            "id": "3d29c4a7-2eed-409d-9aa1-a8f5ca7f8f46",
+            "type": "product"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDocumentRootTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDocumentRootTests.cs
@@ -4,6 +4,7 @@ using JsonApiSerializer.Test.TestUtils;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
+using JsonApiSerializer.Test.Models.Products;
 using Xunit;
 
 namespace JsonApiSerializer.Test.DeserializationTests
@@ -21,6 +22,21 @@ namespace JsonApiSerializer.Test.DeserializationTests
                 new JsonApiSerializerSettings());
 
             AssertArticlesMatchData(articles);
+        }
+
+        [Fact]
+        public void When_included_before_data__with_recursive_references_should_deserialize()
+        {
+            var json = EmbeddedResource.Read("Data.Products.sample-included-first-recursive.json");
+
+            var category = JsonConvert.DeserializeObject<Category>(
+                json,
+                new JsonApiSerializerSettings());
+
+            Assert.NotNull(category);
+            Assert.Equal("MyCategory", category.Name);
+            Assert.Single(category.Products);
+            Assert.Equal("MyCategory", category.Products[0].Category.Name);
         }
 
         [Fact]

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Data\Articles\sample-included-first-recursive.json" />
     <None Remove="Data\Articles\sample-with-full-link.json" />
     <None Remove="Data\Articles\sample-with-inherited-types.json" />
     <None Remove="Data\Articles\sample-with-link-null.json" />
@@ -14,6 +15,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Data\Articles\author-comments-null.json" />
+    <EmbeddedResource Include="Data\Products\sample-included-first-recursive.json" />
     <EmbeddedResource Include="Data\Articles\sample-with-full-link.json" />
     <EmbeddedResource Include="Data\Articles\sample-without-included.json" />
     <EmbeddedResource Include="Data\Articles\sample-with-inherited-types.json" />

--- a/tests/JsonApiSerializer.Test/Models/Products/Category.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/Category.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JsonApiSerializer.Test.Models.Products
+{
+    public class Category
+    {
+        public string Type { get; set; } = "category";
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public Product[] Products { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Products/Product.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/Product.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JsonApiSerializer.Test.Models.Products
+{
+    public class Product
+    {
+        public string Type { get; set; } = "product";
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Category Category { get; set; }
+        public Seller[] Sellers { get; set; }
+    }
+}

--- a/tests/JsonApiSerializer.Test/Models/Products/Seller.cs
+++ b/tests/JsonApiSerializer.Test/Models/Products/Seller.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JsonApiSerializer.Test.Models.Products
+{
+    public class Seller
+    {
+        public string Type { get; set; } = "seller";
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public Product[] Products { get; set; }
+    }
+}


### PR DESCRIPTION
Modify `DocumentRootConverter` to force interpretation of `data` section first
Add POC sample json, object and unit tests.