### PR TITLE
Fix ResolveAsRootData calling GetValue(root) with root as null

### DIFF
--- a/src/JsonApiSerializer/JsonConverters/DocumentRootConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/DocumentRootConverter.cs
@@ -237,7 +237,7 @@ namespace JsonApiSerializer.JsonConverters
             var dataProp = objContract.Properties.GetClosestMatchProperty("data");
 
             var root = serializer.Deserialize(reader, documentRootType);
-            return dataProp.ValueProvider.GetValue(root);
+            return root != null ? dataProp.ValueProvider.GetValue(root) : null;
         }
 
         internal static void ResolveAsRootData(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
- Issue:
	- 
	- When trying to unserialize some invalid specific invalid JSON the library calls dataProp.ValueProvider.GetValue(root) with root as null, thus leading to a null pointer exception.

- Solution:
	- 
	- Add a check beforehand to check whether deserialization resulted in null. If it did, then just return null directly.


- Extra notes:
	- 
	- This should be fixed because some people log unchecked exceptions in a centralized manner thus it could be used to flood logs (DOS) etc

- Example json:
`{
	"data":
	{
		"type": "test",
		"attributes": {
			"testing": [ABC]
	}
}`