### PR TITLE
Upgrade Newtonsoft.Json to v13.0.2. | Continue Development for JsonApiSerializer

### DIFF
--- a/src/JsonApiSerializer/ContractResolvers/Contracts/JsonObjectContractWrap.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Contracts/JsonObjectContractWrap.cs
@@ -1,11 +1,4 @@
-﻿using JsonApiSerializer.JsonApi;
-using JsonApiSerializer.JsonApi.WellKnown;
-using JsonApiSerializer.JsonConverters;
-using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using Newtonsoft.Json.Serialization;
 
 namespace JsonApiSerializer.ContractResolvers.Contracts
 {

--- a/src/JsonApiSerializer/ContractResolvers/Contracts/JsonObjectContractWrap.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Contracts/JsonObjectContractWrap.cs
@@ -31,7 +31,7 @@ namespace JsonApiSerializer.ContractResolvers.Contracts
             ItemReferenceLoopHandling = jsonObjectContract.ItemReferenceLoopHandling;
             ItemTypeNameHandling = jsonObjectContract.ItemTypeNameHandling;
 
-            //poulate JsonContract fields
+            //populate JsonContract fields
             CreatedType = jsonObjectContract.CreatedType;
             IsReference = jsonObjectContract.IsReference;
             Converter = jsonObjectContract.Converter;

--- a/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceIdentifierContract.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceIdentifierContract.cs
@@ -1,11 +1,6 @@
-﻿using JsonApiSerializer.JsonApi;
-using JsonApiSerializer.JsonApi.WellKnown;
-using JsonApiSerializer.JsonConverters;
+﻿using JsonApiSerializer.JsonApi.WellKnown;
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace JsonApiSerializer.ContractResolvers.Contracts
 {

--- a/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceObjectContract.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceObjectContract.cs
@@ -1,11 +1,9 @@
-﻿using JsonApiSerializer.JsonApi;
-using JsonApiSerializer.JsonApi.WellKnown;
+﻿using JsonApiSerializer.JsonApi.WellKnown;
 using JsonApiSerializer.JsonConverters;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace JsonApiSerializer.ContractResolvers.Contracts
 {

--- a/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceRelationshipContract.cs
+++ b/src/JsonApiSerializer/ContractResolvers/Contracts/ResourceRelationshipContract.cs
@@ -1,11 +1,5 @@
-﻿using JsonApiSerializer.JsonApi;
-using JsonApiSerializer.JsonApi.WellKnown;
-using JsonApiSerializer.JsonConverters;
+﻿using JsonApiSerializer.JsonApi.WellKnown;
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace JsonApiSerializer.ContractResolvers.Contracts
 {

--- a/src/JsonApiSerializer/JsonApi/Links.cs
+++ b/src/JsonApiSerializer/JsonApi/Links.cs
@@ -5,7 +5,6 @@ namespace JsonApiSerializer.JsonApi
     /// <summary>
     /// Represents a set of links.
     /// </summary>
-    /// <seealso cref="System.Collections.Generic.Dictionary{System.String, JsonApiSerializer.JsonApi.Link}" />
     public class Links : Dictionary<string, Link>
     {
     }

--- a/src/JsonApiSerializer/JsonApi/Meta.cs
+++ b/src/JsonApiSerializer/JsonApi/Meta.cs
@@ -6,7 +6,6 @@ namespace JsonApiSerializer.JsonApi
     /// <summary>
     /// Represents generic MetaData.
     /// </summary>
-    /// <seealso cref="System.Collections.Generic.Dictionary{System.String, Newtonsoft.Json.Linq.JToken}" />
     public class Meta : Dictionary<string, JToken>
     {
     }

--- a/src/JsonApiSerializer/JsonApi/ResourceIdentifier.cs
+++ b/src/JsonApiSerializer/JsonApi/ResourceIdentifier.cs
@@ -8,7 +8,7 @@ namespace JsonApiSerializer.JsonApi
         /// <summary>
         /// Creates a Relationship for a given type.
         /// </summary>
-        /// <typeparam name="TData">The type of the data.</typeparam>
+        /// <typeparam name="TResourceObject">The type of the data.</typeparam>
         public static ResourceIdentifier<TResourceObject> Create<TResourceObject>(TResourceObject resourceObject)
         {
             return new ResourceIdentifier<TResourceObject>

--- a/src/JsonApiSerializer/JsonApi/WellKnown/IResourceIdentifier.cs
+++ b/src/JsonApiSerializer/JsonApi/WellKnown/IResourceIdentifier.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace JsonApiSerializer.JsonApi.WellKnown
+﻿namespace JsonApiSerializer.JsonApi.WellKnown
 {
     interface IResourceIdentifier<TResourceObject>
     {

--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -3,15 +3,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.9.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
     <PackageLicense>MIT</PackageLicense>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
-    <AssemblyVersion>1.9.0.0</AssemblyVersion>
-    <FileVersion>1.9.0.0</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -3,15 +3,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
     <PackageLicense>MIT</PackageLicense>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
-    <AssemblyVersion>1.8.0.0</AssemblyVersion>
-    <FileVersion>1.8.0.0</FileVersion>
+    <AssemblyVersion>1.9.0.0</AssemblyVersion>
+    <FileVersion>1.9.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -1,19 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.5;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net45;net6.0;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.7.4</Version>
+    <Version>1.8.0</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
     <PackageLicense>MIT</PackageLicense>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
-    <AssemblyVersion>1.7.4.0</AssemblyVersion>
-    <FileVersion>1.7.4.0</FileVersion>
-    <PackageReleaseNotes>Fixed issue that would cuase stackoverflow errors when handling circular references when `included` section is present before `data`</PackageReleaseNotes>
+    <AssemblyVersion>1.8.0.0</AssemblyVersion>
+    <FileVersion>1.8.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>1.8.0</Version>
     <Authors>Alex Davies</Authors>

--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;net45;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>1.8.0</Version>
     <Authors>Alex Davies</Authors>

--- a/src/JsonApiSerializer/JsonApiSerializer.csproj
+++ b/src/JsonApiSerializer/JsonApiSerializer.csproj
@@ -6,7 +6,7 @@
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>JsonApiSerializer supports configurationless serializing and deserializing objects into the json:api format (http://jsonapi.org).</Description>
-    <PackageLicenseUrl>https://github.com/codecutout/JsonApiSerializer/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicense>MIT</PackageLicense>
     <PackageProjectUrl>https://github.com/codecutout/JsonApiSerializer</PackageProjectUrl>
     <PackageTags>jsonapiserializer jsonapi json:api json.net serialization deserialization jsonapi.net</PackageTags>
     <AssemblyVersion>1.7.4.0</AssemblyVersion>

--- a/src/JsonApiSerializer/JsonConverters/ErrorConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ErrorConverter.cs
@@ -4,7 +4,6 @@ using JsonApiSerializer.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 

--- a/src/JsonApiSerializer/JsonConverters/ErrorConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ErrorConverter.cs
@@ -24,7 +24,7 @@ namespace JsonApiSerializer.JsonConverters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            //we may be starting the deserialization here, if thats the case we need to resolve this object as the root
+            //we may be starting the deserialization here, if that's the case we need to resolve this object as the root
             var serializationData = SerializationData.GetSerializationData(reader);
             if (!serializationData.HasProcessedDocumentRoot)
             {

--- a/src/JsonApiSerializer/JsonConverters/ErrorListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ErrorListConverter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JsonApiSerializer.JsonApi.WellKnown;
 using JsonApiSerializer.SerializationState;
 using JsonApiSerializer.Util;
 using Newtonsoft.Json;

--- a/src/JsonApiSerializer/JsonConverters/ErrorListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ErrorListConverter.cs
@@ -23,7 +23,7 @@ namespace JsonApiSerializer.JsonConverters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            //we may be starting the deserialization here, if thats the case we need to resolve this object as the root
+            //we may be starting the deserialization here, if that's the case we need to resolve this object as the root
             var serializationData = SerializationData.GetSerializationData(reader);
             if (!serializationData.HasProcessedDocumentRoot)
             {

--- a/src/JsonApiSerializer/JsonConverters/IncludedConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/IncludedConverter.cs
@@ -21,7 +21,7 @@ namespace JsonApiSerializer.JsonConverters
             
             if (!serializationData.Included.TryGetValue(reference, out var existingObject))
             {
-                //we dont know what type this object should be so we will just save it as a JObject
+                //we don't know what type this object should be so we will just save it as a JObject
                 var unknownObject = serializer.Deserialize<JObject>(forkableReader);
                 serializationData.Included.Add(reference, unknownObject);
                 return unknownObject;

--- a/src/JsonApiSerializer/JsonConverters/ResourceIdentifierConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceIdentifierConverter.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.JsonConverters
 {

--- a/src/JsonApiSerializer/JsonConverters/ResourceIdentifierConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceIdentifierConverter.cs
@@ -73,7 +73,7 @@ namespace JsonApiSerializer.JsonConverters
                     throw new JsonApiFormatException(
                        writer.Path,
                        $"Expected to find a resource identifier or resource object, but found '{value}'",
-                       "Resource indentifier objects MUST contain 'id' members");
+                       "Resource identifier objects MUST contain 'id' members");
             }
            
         }
@@ -214,7 +214,7 @@ namespace JsonApiSerializer.JsonConverters
                     throw new JsonApiFormatException(
                        forkableReader.FullPath,
                        $"Expected to find a resource identifier or resource object, but found '{objectType}'",
-                       "Resource indentifier objects MUST contain 'id' members");
+                       "Resource identifier objects MUST contain 'id' members");
             }
         }
 
@@ -250,7 +250,7 @@ namespace JsonApiSerializer.JsonConverters
                        serializer);
 
             //we will only set the resource object if we have rendered the included
-            //value somehwere, if we have not it means the value was actaully provided
+            //value somewhere, if we have not it means the value was actually provided
             var valueProvider = resourceIdentifierContract.ResourceObjectProperty.ValueProvider;
             serializationData.PostProcessingActions.Add(() =>
             {

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -1,19 +1,14 @@
 ﻿using JsonApiSerializer.ContractResolvers;
 using JsonApiSerializer.ContractResolvers.Contracts;
 using JsonApiSerializer.Exceptions;
-using JsonApiSerializer.JsonApi;
 using JsonApiSerializer.JsonApi.WellKnown;
-using JsonApiSerializer.JsonConverters;
 using JsonApiSerializer.SerializationState;
 using JsonApiSerializer.Util;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.JsonConverters

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -116,8 +116,8 @@ namespace JsonApiSerializer.JsonConverters
                         // can access it down the line.
                         // next breaking change remove support for ResourceObjectConverter 
                         // member converters
-                        if (prop.MemberConverter != null)
-                            serializationData.ConverterStack.Push(prop.MemberConverter);
+                        if (prop.Converter != null)
+                            serializationData.ConverterStack.Push(prop.Converter);
 
                         ReaderUtil.TryPopulateProperty(
                           serializer,
@@ -126,7 +126,7 @@ namespace JsonApiSerializer.JsonConverters
                           reader,
                           overrideConverter: contractResolver.ResourceRelationshipConverter);
 
-                        if (prop.MemberConverter != null)
+                        if (prop.Converter != null)
                             serializationData.ConverterStack.Pop();
                     }
                 }
@@ -230,9 +230,9 @@ namespace JsonApiSerializer.JsonConverters
                         writer.WriteStartObject();
                     }
                     writer.WritePropertyName(attributeProperty.PropertyName);
-                    if (attributeProperty.MemberConverter?.CanWrite == true)
+                    if (attributeProperty.Converter?.CanWrite == true)
                     {
-                        attributeProperty.MemberConverter.WriteJson(writer, attributeValue, serializer);
+                        attributeProperty.Converter.WriteJson(writer, attributeValue, serializer);
                     }
                     else if (attributeValue is string attributeString)
                     {
@@ -270,8 +270,8 @@ namespace JsonApiSerializer.JsonConverters
                     writer.WriteStartObject();
                 }
 
-                if (relationshipProperty.MemberConverter != null)
-                    serializationData.ConverterStack.Push(relationshipProperty.MemberConverter);
+                if (relationshipProperty.Converter != null)
+                    serializationData.ConverterStack.Push(relationshipProperty.Converter);
 
                 writer.WritePropertyName(relationshipProperty.PropertyName);
                 jsonApiContractResolver.ResourceRelationshipConverter.WriteNullableJson(
@@ -280,7 +280,7 @@ namespace JsonApiSerializer.JsonConverters
                     relationshipValue,
                     serializer);
 
-                if (relationshipProperty.MemberConverter != null)
+                if (relationshipProperty.Converter != null)
                     serializationData.ConverterStack.Pop();
 
             }
@@ -298,8 +298,8 @@ namespace JsonApiSerializer.JsonConverters
                         writer.WriteStartObject();
                     }
 
-                    if (relationshipProperty.MemberConverter != null)
-                        serializationData.ConverterStack.Push(relationshipProperty.MemberConverter);
+                    if (relationshipProperty.Converter != null)
+                        serializationData.ConverterStack.Push(relationshipProperty.Converter);
 
                     writer.WritePropertyName(relationshipProperty.PropertyName);
                     jsonApiContractResolver.ResourceRelationshipConverter.WriteNullableJson(
@@ -308,7 +308,7 @@ namespace JsonApiSerializer.JsonConverters
                         relationshipValue,
                         serializer);
 
-                    if (relationshipProperty.MemberConverter != null)
+                    if (relationshipProperty.Converter != null)
                         serializationData.ConverterStack.Pop();
                 }
             }

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectConverter.cs
@@ -47,7 +47,7 @@ namespace JsonApiSerializer.JsonConverters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            //we may be starting the deserialization here, if thats the case we need to resolve this object as the root
+            //we may be starting the deserialization here, if that's the case we need to resolve this object as the root
             var serializationData = SerializationData.GetSerializationData(reader);
             if (!serializationData.HasProcessedDocumentRoot)
                 return DocumentRootConverter.ResolveAsRootData(reader, objectType, serializer);
@@ -67,11 +67,11 @@ namespace JsonApiSerializer.JsonConverters
 
             var reference = ReaderUtil.ReadAheadToIdentifyObject(forkableReader);
 
-            //if we dont have this object already we will create it
+            //if we don't have this object already we will create it
             existingValue = existingValue ?? CreateObject(objectType, reference.Type, serializer);
 
 
-            //mark this object as a possible include. We need to do this before deserialiazing
+            //mark this object as a possible include. We need to do this before deserializing
             //the relationship; It could have relationships that reference back to this object
             serializationData.Included[reference] = existingValue;
 
@@ -115,7 +115,7 @@ namespace JsonApiSerializer.JsonConverters
                             continue;
 
                         // This is a massive hack. MemberConverters used to work and allowed
-                        // modifying a members create object. Unfortunatly Resource Identifiers
+                        // modifying a members create object. Unfortunately Resource Identifiers
                         // are no longer created by this object converter. We are passing the
                         // convertor via the serialization data so ResourceIdentifierConverter
                         // can access it down the line.
@@ -165,7 +165,7 @@ namespace JsonApiSerializer.JsonConverters
                 throw new JsonApiFormatException(
                       writer.Path,
                       $"Expected to find to find resource object, but found '{value}'",
-                      "Resource indentifier objects MUST contain 'id' members");
+                      "Resource identifier objects MUST contain 'id' members");
 
             serializationData.ConverterStack.Push(this);
 
@@ -200,7 +200,7 @@ namespace JsonApiSerializer.JsonConverters
 
             // store all the relationships, that appear to be attributes from the 
             // property declared type, types but the runtime type shows they are
-            // actaully relationships
+            // actually relationships
             List<KeyValuePair<JsonProperty, object>> undeclaredRelationships = null;
 
             //serialize attributes
@@ -210,12 +210,12 @@ namespace JsonApiSerializer.JsonConverters
                 var attributeProperty = metadata.Attributes[i];
                 if (WriterUtil.ShouldWriteProperty(value, attributeProperty, serializer, out object attributeValue))
                 {
-                    // some relationships are not decalred as such. They exist in properties
+                    // some relationships are not declared as such. They exist in properties
                     // with declared types of `object` but the runtime object within is a
                     // relationship. We will check here if this attribute property is really
                     // a relationship, and if it is store it to process later
 
-                    // NOTE: this behviour it leads to nulls being inconsistantly attribute/relationship.
+                    // NOTE: this behaviour it leads to nulls being inconsistently attribute/relationship.
                     // leaving in for backward compatability but remove on next breaking change
                     var attributeValueType = attributeValue?.GetType();
                     if (attributeValueType != null

--- a/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceObjectListConverter.cs
@@ -1,14 +1,11 @@
-﻿using JsonApiSerializer.ContractResolvers;
-using JsonApiSerializer.ContractResolvers.Contracts;
+﻿using JsonApiSerializer.ContractResolvers.Contracts;
 using JsonApiSerializer.Exceptions;
-using JsonApiSerializer.JsonApi.WellKnown;
 using JsonApiSerializer.SerializationState;
 using JsonApiSerializer.Util;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.JsonConverters
 {

--- a/src/JsonApiSerializer/JsonConverters/ResourceRelationshipConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceRelationshipConverter.cs
@@ -1,16 +1,12 @@
 ﻿using JsonApiSerializer.ContractResolvers;
 using JsonApiSerializer.ContractResolvers.Contracts;
 using JsonApiSerializer.Exceptions;
-using JsonApiSerializer.JsonApi;
 using JsonApiSerializer.JsonApi.WellKnown;
 using JsonApiSerializer.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.JsonConverters
 {

--- a/src/JsonApiSerializer/JsonConverters/ResourceRelationshipConverter.cs
+++ b/src/JsonApiSerializer/JsonConverters/ResourceRelationshipConverter.cs
@@ -102,7 +102,7 @@ namespace JsonApiSerializer.JsonConverters
         public void WriteNullableJson(JsonWriter writer, Type declaredType, object value, JsonSerializer serializer)
         {
             // WriteJson should NEVER be passed a null a value, 
-            // so we will handle nulls seperately here
+            // so we will handle nulls separately here
             if(value == null)
             {
                 writer.WriteStartObject();
@@ -121,7 +121,7 @@ namespace JsonApiSerializer.JsonConverters
         {
             var contract = serializer.ContractResolver.ResolveContract(declaredType);
 
-            //if its a null relationship, we want to know what hte data field was
+            //if its a null relationship, we want to know what the data field was
             if (contract is ResourceRelationshipContract rrc)
                 contract = serializer.ContractResolver.ResolveContract(rrc.DataProperty.PropertyType);
             
@@ -144,7 +144,7 @@ namespace JsonApiSerializer.JsonConverters
             var jsonApiContractResolver = (JsonApiContractResolver)serializer.ContractResolver;
             var contract = jsonApiContractResolver.ResolveContract(objectType);
 
-            // we be a ResourceObject rather than a RelationshpObject
+            // we want it to be a ResourceObject rather than a RelationshipObject
             // if so we will just read the data property of the resource object
             if (!(contract is ResourceRelationshipContract rrc))
             {

--- a/src/JsonApiSerializer/SerializationState/SerializationData.cs
+++ b/src/JsonApiSerializer/SerializationState/SerializationData.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using JsonApiSerializer.Util.JsonApiConverter.Util;
 using System;
-using Newtonsoft.Json.Linq;
 
 namespace JsonApiSerializer.SerializationState
 {

--- a/src/JsonApiSerializer/Util/ListUtil.cs
+++ b/src/JsonApiSerializer/Util/ListUtil.cs
@@ -54,7 +54,7 @@ namespace JsonApiSerializer.Util
             if (!IsList(listType, out elementType))
                 throw new ArgumentException($"{nameof(listType)} must be a list. {nameof(listType)} was {listType}", nameof(listType));
 
-            //if we are an array we need to create wtih Array.CreateInstance
+            //if we are an array we need to create with Array.CreateInstance
             if (listType.IsArray)
             {
                 var elementList = elements.ToArray();

--- a/src/JsonApiSerializer/Util/ReaderUtil.cs
+++ b/src/JsonApiSerializer/Util/ReaderUtil.cs
@@ -141,9 +141,9 @@ namespace JsonApiSerializer.Util
             {
                 propValue = overrideConverter.ReadJson(value, property.PropertyType, null, serializer);
             }
-            else if (property.MemberConverter != null && property.MemberConverter.CanRead)
+            else if (property.Converter != null && property.Converter.CanRead)
             {
-                propValue = property.MemberConverter.ReadJson(value, property.PropertyType, null, serializer);
+                propValue = property.Converter.ReadJson(value, property.PropertyType, null, serializer);
             }
             else
             {

--- a/src/JsonApiSerializer/Util/ReaderUtil.cs
+++ b/src/JsonApiSerializer/Util/ReaderUtil.cs
@@ -175,7 +175,7 @@ namespace JsonApiSerializer.Util
             }
             else if (reader.TokenType == JsonToken.None || reader.TokenType == JsonToken.Null || reader.TokenType == JsonToken.Undefined)
             {
-                //we dont have a value so return empty array
+                //we don't have a value so return empty array
                 yield break;
             }
             else
@@ -260,9 +260,9 @@ namespace JsonApiSerializer.Util
 
         public static object CreateObject(SerializationData serializationData, Type objectType, string jsonApiType, JsonSerializer serializer)
         {
-            // Hack: To keep backward compatability we are not sure what resouceObjectConverter to use
+            // Hack: To keep backward compatability we are not sure what resourceObjectConverter to use
             // we need to check if either one was defined as a serializer, or if one was defined as
-            // furher up the stack (i.e. a member converter)
+            // further up the stack (i.e. a member converter)
 
             for (var i = 0; i < serializer.Converters.Count; i++)
             {

--- a/src/JsonApiSerializer/Util/ReaderUtil.cs
+++ b/src/JsonApiSerializer/Util/ReaderUtil.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.Util
 {

--- a/src/JsonApiSerializer/Util/WriterUtil.cs
+++ b/src/JsonApiSerializer/Util/WriterUtil.cs
@@ -1,7 +1,6 @@
 ﻿using JsonApiSerializer.ContractResolvers;
 using JsonApiSerializer.ContractResolvers.Contracts;
 using JsonApiSerializer.Exceptions;
-using JsonApiSerializer.JsonApi.WellKnown;
 using JsonApiSerializer.JsonConverters;
 using JsonApiSerializer.SerializationState;
 using Newtonsoft.Json;
@@ -9,7 +8,6 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 
 namespace JsonApiSerializer.Util
 {

--- a/src/JsonApiSerializer/Util/WriterUtil.cs
+++ b/src/JsonApiSerializer/Util/WriterUtil.cs
@@ -92,9 +92,9 @@ namespace JsonApiSerializer.Util
 
         private static string CalculateDefaultJsonApiTypeFromObjectType(Type objectType, SerializationData serializationData, JsonSerializer serializer)
         {
-            // Hack: To keep backward compatability we are not sure what resouceObjectConverter to use
+            // Hack: To keep backward compatability we are not sure what resourceObjectConverter to use
             // we need to check if either one was defined as a serializer, or if one was defined as
-            // furher up the stack (i.e. a member converter)
+            // further up the stack (i.e. a member converter)
 
             for (var i = 0; i < serializer.Converters.Count; i++)
             {

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDateTimeTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationDateTimeTests.cs
@@ -63,7 +63,9 @@ namespace JsonApiSerializer.Test.DeserializationTests
 }
 ";
             var settings = new JsonApiSerializerSettings();
-            var localOffset = new DateTimeOffset(new DateTime(0), TimeZoneInfo.Local.BaseUtcOffset).ToString("zzz");
+
+            var dt = DateTime.Parse("2017-01-01T12:00:00");
+            var localOffset = new DateTimeOffset(dt, TimeZoneInfo.Local.GetUtcOffset(dt)).ToString("zzz");
 
             var dateTimes = JsonConvert.DeserializeObject<DateTimes>(json, settings);
 

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationPerformanceBenchmarkTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationPerformanceBenchmarkTests.cs
@@ -27,8 +27,8 @@ namespace JsonApiSerializer.Test.DeserializationTests
 
             var json = EmbeddedResource.Read("Data.Articles.sample-with-full-link.json");
 
-            var jsonIterations = CountIterations<DocumentRootVanillaJson<List<ArticleVanillaJson>>>(TimeSpan.FromMilliseconds(testTime.TotalMilliseconds / 2), json, new JsonSerializerSettings());
-            var jsonApiIterations = CountIterations<List<Article>>(TimeSpan.FromMilliseconds(testTime.TotalMilliseconds / 2), json, new JsonApiSerializerSettings());
+            var jsonIterations = CountIterations<DocumentRootVanillaJson<List<ArticleVanillaJson>>>(testTime, json, new JsonSerializerSettings());
+            var jsonApiIterations = CountIterations<List<Article>>(testTime, json, new JsonApiSerializerSettings());
 
             output.WriteLine($"Json performed {jsonIterations} deserializations in {testTime.TotalSeconds}s");
             output.WriteLine($"JsonApi performed {jsonApiIterations} deserializations in {testTime.TotalSeconds}s");

--- a/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationPerformanceBenchmarkTests.cs
+++ b/tests/JsonApiSerializer.Test/DeserializationTests/DeserializationPerformanceBenchmarkTests.cs
@@ -27,8 +27,8 @@ namespace JsonApiSerializer.Test.DeserializationTests
 
             var json = EmbeddedResource.Read("Data.Articles.sample-with-full-link.json");
 
-            var jsonIterations = CountIterations<DocumentRootVanillaJson<List<ArticleVanillaJson>>>(testTime / 2, json, new JsonSerializerSettings());
-            var jsonApiIterations = CountIterations<List<Article>>(testTime / 2, json, new JsonApiSerializerSettings());
+            var jsonIterations = CountIterations<DocumentRootVanillaJson<List<ArticleVanillaJson>>>(TimeSpan.FromMilliseconds(testTime.TotalMilliseconds / 2), json, new JsonSerializerSettings());
+            var jsonApiIterations = CountIterations<List<Article>>(TimeSpan.FromMilliseconds(testTime.TotalMilliseconds / 2), json, new JsonApiSerializerSettings());
 
             output.WriteLine($"Json performed {jsonIterations} deserializations in {testTime.TotalSeconds}s");
             output.WriteLine($"JsonApi performed {jsonApiIterations} deserializations in {testTime.TotalSeconds}s");

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
+++ b/tests/JsonApiSerializer.Test/JsonApiSerializer.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,12 +35,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/JsonApiSerializer.Test/SerializationTests/SerializationPerformanceTests.cs
+++ b/tests/JsonApiSerializer.Test/SerializationTests/SerializationPerformanceTests.cs
@@ -39,8 +39,8 @@ namespace JsonApiSerializer.Test.SerializationTests
             var jsonString = JsonConvert.SerializeObject(json, new JsonSerializerSettings() { Formatting = Formatting.Indented });
             Assert.Equal(jsonApiString, jsonString, JsonStringEqualityComparer.InstanceIgnoreArrayOrder);
 
-            var jsonIterations = CountIterations(testTime.TotalMilliseconds / 2, json, new JsonSerializerSettings());
-            var jsonApiIterations = CountIterations(testTime.TotalMilliseconds / 2, jsonApi, new JsonApiSerializerSettings());
+            var jsonIterations = CountIterations(testTime, json, new JsonSerializerSettings());
+            var jsonApiIterations = CountIterations(testTime, jsonApi, new JsonApiSerializerSettings());
 
             output.WriteLine($"Json performed {jsonIterations} serializations in {testTime.TotalSeconds}s");
             output.WriteLine($"JsonApi performed {jsonApiIterations} serializations in {testTime.TotalSeconds}s");
@@ -59,7 +59,7 @@ namespace JsonApiSerializer.Test.SerializationTests
             return DocumentRoot.Create(fixture.CreateMany<Article>(listSize).ToList());
         }
 
-        public static int CountIterations(double timeout, object objToSerialize, JsonSerializerSettings settings)
+        public static int CountIterations(TimeSpan timeout, object objToSerialize, JsonSerializerSettings settings)
         {
             var sw = new Stopwatch();
             int iterations = 0;
@@ -68,7 +68,7 @@ namespace JsonApiSerializer.Test.SerializationTests
             {
                 GC.Collect();
                 sw.Start();
-                while(sw.ElapsedMilliseconds < timeout)
+                while(sw.Elapsed < timeout)
                 {
                     //JsonConvert.SerializeObject(objToSerialize, settings);
 

--- a/tests/JsonApiSerializer.Test/SerializationTests/SerializationPerformanceTests.cs
+++ b/tests/JsonApiSerializer.Test/SerializationTests/SerializationPerformanceTests.cs
@@ -39,8 +39,8 @@ namespace JsonApiSerializer.Test.SerializationTests
             var jsonString = JsonConvert.SerializeObject(json, new JsonSerializerSettings() { Formatting = Formatting.Indented });
             Assert.Equal(jsonApiString, jsonString, JsonStringEqualityComparer.InstanceIgnoreArrayOrder);
 
-            var jsonIterations = CountIterations(testTime / 2, json, new JsonSerializerSettings());
-            var jsonApiIterations = CountIterations(testTime / 2, jsonApi, new JsonApiSerializerSettings());
+            var jsonIterations = CountIterations(testTime.TotalMilliseconds / 2, json, new JsonSerializerSettings());
+            var jsonApiIterations = CountIterations(testTime.TotalMilliseconds / 2, jsonApi, new JsonApiSerializerSettings());
 
             output.WriteLine($"Json performed {jsonIterations} serializations in {testTime.TotalSeconds}s");
             output.WriteLine($"JsonApi performed {jsonApiIterations} serializations in {testTime.TotalSeconds}s");
@@ -59,7 +59,7 @@ namespace JsonApiSerializer.Test.SerializationTests
             return DocumentRoot.Create(fixture.CreateMany<Article>(listSize).ToList());
         }
 
-        public static int CountIterations(TimeSpan timeout, object objToSerialize, JsonSerializerSettings settings)
+        public static int CountIterations(double timeout, object objToSerialize, JsonSerializerSettings settings)
         {
             var sw = new Stopwatch();
             int iterations = 0;
@@ -68,7 +68,7 @@ namespace JsonApiSerializer.Test.SerializationTests
             {
                 GC.Collect();
                 sw.Start();
-                while(sw.Elapsed < timeout)
+                while(sw.ElapsedMilliseconds < timeout)
                 {
                     //JsonConvert.SerializeObject(objToSerialize, settings);
 


### PR DESCRIPTION
I've recently stumbled upon this project and incorporated it into my new pet project. Imho, this project is superior to the more active / larger ["JsonApiDotnetCore"](https://github.com/json-api-dotnet/JsonApiDotNetCore) in the sense that it doesn't add a bunch of magic to the app, but simply focuses on de- / serializing. 

I've forked this project and upgraded Newtonsoft.Json as well as the Test-Project's dependencies to the latest version, fixing a bunch of security vulnerabilities and modernizing / fixing deprecation notices in the process.

Running the tests succeeds after the upgrade / refactor, so i'd say it's safe to update.

Additionally, I've refactored the csproj and set target frameworks to netstandard2.0, which is the latest version of the standard still supporting .NET Framework 4.6.1+ in addition to .NET (Core)
 
Regardless if this PR reaches the maintainers and (hopefully) gets approved, i'm still planning to continue development of my fork over on my Github profile, with plans of starting a v2.0, that complies to JSON:API v1.1 spec, targets newer .NET versions and deprecates support for .NET Framework 4.x while keeping security updates for the v1